### PR TITLE
PD-325 publish environment-specific packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ slices = service.get_slices(False)
 # Publish an open file handle as version 2.0.0 of the service
 service.publish(file, '2.0.0')
 
+# Publish an open file handle as version 2.0.0 of the service
+# configured for environment MyEnv
+service.publish(file, '2.0.0', 'MyEnv')
+
 # Deploy the service
 deploy_id = service.deploy()
 

--- a/envmgr/service.py
+++ b/envmgr/service.py
@@ -57,13 +57,13 @@ class Service(object):
             raise Exception('There is no deploy_id set for this service')
         return self.client.get_deployment(self.__deploy_id)
 
-    def publish(self, file, version=None):
+    def publish(self, file, version=None, env=None):
         """
         Accept an open file object and publish it as a given
         version of this service. Raises on HTTP error
         """
         self.__require_version_set(version)
-        package_path = self.client.get_package_upload_url(self.name, self.version)
+        package_path = self.client.get_package_upload_url_environment(self.name, self.version, env) if env is not None else self.client.get_package_upload_url(self.name, self.version)
         is_dict = isinstance(package_path, dict)
         upload_url = package_path.get('url') if is_dict else package_path
         headers = {'content-type':'application/zip'}

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -64,6 +64,13 @@ class TestService(TestCase):
         service = Service('TestService', 'TE1')
         service.publish({}, '1.0.0')
         mock_package_url.assert_called_with('TestService', '1.0.0')
+
+    @patch('requests.put')
+    @patch('environment_manager.EMApi.get_package_upload_url_environment')
+    def test_publish_with_version_and_env_gets_package_url(self, mock_package_url, mock_requests):
+        service = Service('TestService', 'TE1')
+        service.publish({}, '1.0.0', 'SomeEnv')
+        mock_package_url.assert_called_with('TestService', '1.0.0', 'SomeEnv')
     
     @patch('requests.put')
     @patch('environment_manager.EMApi.get_package_upload_url')


### PR DESCRIPTION
Support publication of environment-specific packages using the Environment Manager API `/package-upload-url/{service}/{version}/{environment}`

https://jira.thetrainline.com/browse/PD-325